### PR TITLE
Add reshuffle feature to redistribute study sessions

### DIFF
--- a/dev-dist/sw.js
+++ b/dev-dist/sw.js
@@ -82,7 +82,7 @@ define(['./workbox-ce4f0d5f'], (function (workbox) { 'use strict';
     "revision": "3ca0b8505b4bec776b69afdba2768812"
   }, {
     "url": "index.html",
-    "revision": "0.eg970n7gjrg"
+    "revision": "0.lloeffh80j"
   }], {});
   workbox.cleanupOutdatedCaches();
   workbox.registerRoute(new workbox.NavigationRoute(workbox.createHandlerBoundToURL("index.html"), {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -647,7 +647,7 @@ function App() {
         if (tasks.length > 0) {
             try {
                 // Generate new study plan
-                const result = preserveManualReschedules 
+                const result = preserveManualReschedules
                     ? generateNewStudyPlanWithPreservation(tasks, settings, fixedCommitments, studyPlans)
                     : generateNewStudyPlan(tasks, settings, fixedCommitments, studyPlans);
                 const newPlans = result.plans;
@@ -730,6 +730,34 @@ function App() {
             } catch (error) {
                 console.error('Study plan refresh failed:', error);
                 setNotificationMessage('Failed to refresh study plan. Please try again.');
+                setTimeout(() => setNotificationMessage(''), 5000);
+            }
+        }
+    };
+
+    // Handle reshuffle study plan to balance workloads
+    const handleReshuffleStudyPlan = () => {
+        if (tasks.length > 0 && studyPlans.length > 0) {
+            try {
+                // Use reshuffle function to redistribute sessions for workload balance
+                const result = reshuffleStudyPlan(studyPlans, tasks, settings, fixedCommitments);
+                const newPlans = result.plans;
+
+                setStudyPlans(newPlans);
+                setLastPlanStaleReason("task");
+                setNotificationMessage('Study plan reshuffled! Sessions redistributed for balanced workload.');
+
+                if (result.suggestions.length > 0) {
+                    const totalUnscheduled = result.suggestions.reduce((sum, s) => sum + s.unscheduledMinutes, 0);
+                    setTimeout(() => {
+                        setNotificationMessage(`Study plan reshuffled! Note: ${Math.round(totalUnscheduled / 60)} hours could not be scheduled. Check the suggestions panel for details.`);
+                    }, 5100);
+                }
+
+                setTimeout(() => setNotificationMessage(''), 5000);
+            } catch (error) {
+                console.error('Study plan reshuffle failed:', error);
+                setNotificationMessage('Failed to reshuffle study plan. Please try again.');
                 setTimeout(() => setNotificationMessage(''), 5000);
             }
         }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Calendar, CheckSquare, Clock, Settings as SettingsIcon, BarChart3, CalendarDays, Lightbulb, Edit, Trash2, Menu, X, HelpCircle, Trophy, User } from 'lucide-react';
 import { Task, StudyPlan, UserSettings, FixedCommitment, StudySession, TimerState } from './types';
 import { GamificationData, Achievement, DailyChallenge, MotivationalMessage } from './types-gamification';
-import { getUnscheduledMinutesForTasks, getLocalDateString, checkCommitmentConflicts, generateNewStudyPlan, generateNewStudyPlanWithPreservation } from './utils/scheduling';
+import { getUnscheduledMinutesForTasks, getLocalDateString, checkCommitmentConflicts, generateNewStudyPlan, generateNewStudyPlanWithPreservation, reshuffleStudyPlan } from './utils/scheduling';
 import { getAccurateUnscheduledTasks, shouldShowNotifications, getNotificationPriority } from './utils/enhanced-notifications';
 import { enhancedEstimationTracker } from './utils/enhanced-estimation-tracker';
 import {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2383,6 +2383,7 @@ function App() {
                             settings={settings}
                             onAddFixedCommitment={handleAddFixedCommitment}
                             onRefreshStudyPlan={handleRefreshStudyPlan}
+                            onReshuffleStudyPlan={handleReshuffleStudyPlan}
                             onUpdateTask={handleUpdateTask}
                         />
                     )}

--- a/src/components/StudyPlanView.tsx
+++ b/src/components/StudyPlanView.tsx
@@ -14,6 +14,7 @@ interface StudyPlanViewProps {
   settings: UserSettings; // Added settings prop
   onAddFixedCommitment?: (commitment: FixedCommitment) => void; // NEW PROP
   onRefreshStudyPlan?: (preserveManualReschedules: boolean) => void; // NEW PROP for refresh with options
+  onReshuffleStudyPlan?: () => void; // NEW PROP for reshuffling study plan
   onUpdateTask?: (taskId: string, updates: Partial<Task>) => void; // NEW PROP for task completion
 }
 

--- a/src/components/StudyPlanView.tsx
+++ b/src/components/StudyPlanView.tsx
@@ -25,7 +25,7 @@ if (typeof window !== 'undefined') {
   }
 }
 
-const StudyPlanView: React.FC<StudyPlanViewProps> = ({ studyPlans, tasks, fixedCommitments, onSelectTask, onGenerateStudyPlan, onUndoSessionDone, onSkipSession, settings, onAddFixedCommitment, onRefreshStudyPlan, onUpdateTask }) => {
+const StudyPlanView: React.FC<StudyPlanViewProps> = ({ studyPlans, tasks, fixedCommitments, onSelectTask, onGenerateStudyPlan, onUndoSessionDone, onSkipSession, settings, onAddFixedCommitment, onRefreshStudyPlan, onReshuffleStudyPlan, onUpdateTask }) => {
   const [notificationMessage, setNotificationMessage] = useState<string | null>(null);
   const [] = useState<{ taskTitle: string; unscheduledMinutes: number } | null>(null);
   const [showRegenerateConfirmation, setShowRegenerateConfirmation] = useState(false);

--- a/src/components/StudyPlanView.tsx
+++ b/src/components/StudyPlanView.tsx
@@ -914,16 +914,31 @@ const StudyPlanView: React.FC<StudyPlanViewProps> = ({ studyPlans, tasks, fixedC
               <Calendar className="text-blue-600 dark:text-blue-400" size={24} />
               <h2 className="text-xl font-semibold text-gray-800 dark:text-white">Note: you should always refresh plan (reset all) when adding or editing tasks</h2>
             </div>
-            <button
-              onClick={handleRefreshClick}
-              className="px-4 py-2 bg-gradient-to-r from-green-500 to-blue-600 text-white text-sm rounded-lg hover:from-green-600 hover:to-blue-700 transition-colors flex items-center space-x-2"
-              title="Refresh and regenerate your study plan"
-            >
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-              </svg>
-              <span>Refresh Plan</span>
-            </button>
+            <div className="flex items-center space-x-3">
+              <button
+                onClick={handleRefreshClick}
+                className="px-4 py-2 bg-gradient-to-r from-green-500 to-blue-600 text-white text-sm rounded-lg hover:from-green-600 hover:to-blue-700 transition-colors flex items-center space-x-2"
+                title="Refresh and regenerate your study plan"
+              >
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                </svg>
+                <span>Refresh Plan</span>
+              </button>
+
+              {onReshuffleStudyPlan && (
+                <button
+                  onClick={() => onReshuffleStudyPlan()}
+                  className="px-4 py-2 bg-gradient-to-r from-purple-500 to-indigo-600 text-white text-sm rounded-lg hover:from-purple-600 hover:to-indigo-700 transition-colors flex items-center space-x-2"
+                  title="Reshuffle sessions to balance workload across days"
+                >
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4" />
+                  </svg>
+                  <span>Reshuffle Plan</span>
+                </button>
+              )}
+            </div>
           </div>
 
           {/* Missed Sessions feature removed - forward focus approach: past sessions are ignored */}


### PR DESCRIPTION
## Purpose

Users requested a study plan reshuffle feature to redistribute sessions across available days for balanced workload distribution. The original implementation was combining sessions instead of moving them to other days as expected. This feature aims to utilize all available days equally, preventing any single day from being overwhelming while preserving session durations, organization, and respecting task deadlines and frequency preferences.

## Code changes

- **Added `reshuffleStudyPlan` function** in `utils/scheduling.ts` that redistributes existing study sessions across available days to balance workload
- **Added reshuffle button** in StudyPlanView component next to the refresh plan button with purple gradient styling
- **Integrated reshuffle handler** in App.tsx that calls the new reshuffle function and provides user feedback
- **Preserved session properties** including durations, task organization, and deadline constraints during redistribution
- **Added workload balancing logic** that calculates ideal hours per day and redistributes sessions to achieve balanced distribution
- **Maintained completed/skipped sessions** in their original positions while only moving pending sessions

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/5a1adea1ece74865babdcf3f6278ff8d/vortex-hub)

👀 [Preview Link](https://5a1adea1ece74865babdcf3f6278ff8d-vortex-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>5a1adea1ece74865babdcf3f6278ff8d</projectId>-->
<!--<branchName>vortex-hub</branchName>-->