### PR TITLE
Improve workload balancing for one-sitting tasks

### DIFF
--- a/src/utils/scheduling.ts
+++ b/src/utils/scheduling.ts
@@ -3332,12 +3332,15 @@ export const generateNewStudyPlanWithPreservation = (
 ): { plans: StudyPlan[]; suggestions: Array<{ taskTitle: string; unscheduledMinutes: number }> } => {
   // First, generate the new study plan
   const result = generateNewStudyPlan(tasks, settings, fixedCommitments, existingStudyPlans);
-  
-  // Then apply manual schedule preservation
+
+  // Apply manual schedule preservation
   const preservedPlans = preserveManualSchedules(result.plans, existingStudyPlans);
-  
+
+  // Apply intelligent workload balancing around one-sitting tasks
+  const balancedPlans = rebalanceAroundOneSittingTasks(preservedPlans, tasks, settings, fixedCommitments);
+
   return {
-    plans: preservedPlans,
+    plans: balancedPlans,
     suggestions: result.suggestions
   };
 };

--- a/src/utils/scheduling.ts
+++ b/src/utils/scheduling.ts
@@ -3641,8 +3641,11 @@ export const generateNewStudyPlanWithPreservation = (
   // Apply intelligent workload balancing around one-sitting tasks
   const balancedPlans = rebalanceAroundOneSittingTasks(preservedPlans, tasks, settings, fixedCommitments);
 
+  // Apply final workload smoothing to minimize daily variation
+  const smoothedPlans = applyWorkloadSmoothing(balancedPlans, tasks, settings, fixedCommitments);
+
   return {
-    plans: balancedPlans,
+    plans: smoothedPlans,
     suggestions: result.suggestions
   };
 };


### PR DESCRIPTION
## Purpose

The user identified issues with inconsistent daily workloads when adding one-sitting tasks that consume most of the available study hours. This creates days with overwhelming workload alongside days with little to no work. The user wanted a solution that maintains the integrity of one-sitting tasks while rebalancing other sessions to create more consistent daily study loads.

## Code changes

- **Smart fallback scheduling**: Added `handleOneSittingFallback()` function that attempts alternative scheduling strategies when one-sitting tasks can't be placed as intended, including splitting into 2 large sessions or progressive scheduling by capacity
- **Workload rebalancing**: Implemented `rebalanceAroundOneSittingTasks()` to identify days with large one-sitting tasks and extract non-one-sitting sessions for redistribution
- **Workload smoothing**: Added `applyWorkloadSmoothing()` to minimize daily variation by moving sessions from overloaded to underloaded days
- **Session redistribution**: Created `redistributeSessionsForBalance()` to intelligently redistribute extracted sessions based on priority and deadline constraints
- **Enhanced study plan generation**: Updated `generateNewStudyPlanWithPreservation()` to apply the new balancing and smoothing algorithms after manual schedule preservation

The changes ensure that one-sitting tasks remain intact while other sessions are redistributed to create more consistent daily workloads across the study schedule.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/5a1adea1ece74865babdcf3f6278ff8d/stellar-garden)

👀 [Preview Link](https://5a1adea1ece74865babdcf3f6278ff8d-stellar-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>5a1adea1ece74865babdcf3f6278ff8d</projectId>-->
<!--<branchName>stellar-garden</branchName>-->